### PR TITLE
Calculate bucket index in worker

### DIFF
--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -33,6 +33,9 @@ const getAggregationparams = params => {
     if (url.searchParams.get("interval")) {
         aggregationParams.interval = url.searchParams.get("interval")
     }
+    if (url.searchParams.get("breaks")) {
+        aggregationParams.breaks = url.searchParams.get("breaks").split(",").map(v => parseFloat(v))
+    }
     return aggregationParams
 };
 


### PR DESCRIPTION
Instead of spitting back the raw value for each cell / frame:
- apply multiplier set by the API to allow floats in integer array (https://github.com/GlobalFishingWatch/mapbox-gl-js/pull/77/files#diff-8bd750c7becd1a8acd993e4afc28415eR13)
- if set by layer-composer generator, uses `breaks` parameter to send to the renderer a bucket index instead of the raw value (if `breaks` is set to `[0, 5, 10, 42]` and value is 12, cell frame will be `2`)

This might give a little performance boost, but the main goal is to be able to prepare in worker more complex calculation, avoiding costly complex MGL expressions during playback. Especially when <a href="https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/140">combining datasets</a> (ie bivariate scale etc)

Needs corresponding layer-composer PR: https://github.com/GlobalFishingWatch/frontend/pull/46

Currently with only 5 breaks, compression is visible so we'll need a higher number of them in our color ramps (before/after):
![Screenshot 2020-08-06 at 10 37 26](https://user-images.githubusercontent.com/1583415/89511858-b8b20580-d7d2-11ea-80bf-685e4f992787.png)

![Screenshot 2020-08-06 at 10 36 51](https://user-images.githubusercontent.com/1583415/89511846-b5b71500-d7d2-11ea-9c03-28e5e66d373d.png)
