### PR TITLE
Temporal grid dataset combination

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,5 +1,5 @@
 version: '1'
 rules:
   - base: master
-    upstream: mapbox:master
+    upstream: mapbox:main
     mergeMethod: none

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "build-prod": "rollup -c --environment BUILD:production",
     "build-prod-min": "rollup -c --environment BUILD:production,MINIFY:true",
     "build-csp": "rollup -c rollup.config.csp.js",
+    "watch-csp": "rollup -c rollup.config.csp.js --watch",
     "build-query-suite": "rollup -c test/integration/rollup.config.test.js",
     "build-flow-types": "mkdir -p dist && cp build/mapbox-gl.js.flow dist/mapbox-gl.js.flow && cp build/mapbox-gl.js.flow dist/mapbox-gl-dev.js.flow",
     "build-css": "postcss -o dist/mapbox-gl.css src/css/mapbox-gl.css",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "test-expressions": "build/run-node test/expression.test.js",
     "test-flow": "build/run-node build/generate-flow-typed-style-spec && flow .",
     "test-cov": "nyc --require=@mapbox/flow-remove-types/register --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
+    "test-aggregate": "tap ./src/util/aggregate.test.mjs",
     "prepublishOnly": "run-s prepare-publish build-flow-types build-dev build-prod-min build-prod build-csp build-css build-style-spec test-build diff-tarball",
     "print-release-url": "node build/print-release-url.js",
     "codegen": "build/run-node build/generate-style-code.js && build/run-node build/generate-struct-arrays.js"

--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -50,7 +50,9 @@ const getFinalurl = (originalUrlString, { singleFrame, interval }) => {
     const finalUrl = new URL(originalUrl.origin + originalUrl.pathname)
 
     finalUrl.searchParams.append('format', 'intArray');
-    finalUrl.searchParams.append('date-range', decodeURI(originalUrl.searchParams.get("date-range")))
+    if (originalUrl.searchParams.get("date-range")) {
+        finalUrl.searchParams.append('date-range', decodeURI(originalUrl.searchParams.get("date-range")))
+    }
     finalUrl.searchParams.append('temporal-aggregation', singleFrame);
     if (interval) {
         finalUrl.searchParams.append('interval', interval);

--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -25,10 +25,7 @@ const getAggregationParams = params => {
         url.searchParams.get("quantizeOffset") || "0"
     );
     const singleFrame = url.searchParams.get("singleFrame") === "true";
-    // We want proxy active as default when api tiles auth is required
-    const proxy = url.searchParams.get("proxy") !== "false";
     const aggregationParams =  {
-        proxy,
         x, y, z,
         singleFrame,
         quantizeOffset,
@@ -50,13 +47,17 @@ const getAggregationParams = params => {
     return aggregationParams
 };
 
-const getFinalurl = (originalUrlString, { singleFrame, interval, proxy = true }) => {
+const getFinalurl = (originalUrlString, { singleFrame, interval }) => {
     const originalUrl = new URL(originalUrlString);
 
     const finalUrl = new URL(originalUrl.origin + originalUrl.pathname)
+
+    // We want proxy active as default when api tiles auth is required
+    const proxy = originalUrl.searchParams.get("proxy") !== "false";
     finalUrl.searchParams.append('proxy', proxy);
     finalUrl.searchParams.append('format', 'intArray');
     finalUrl.searchParams.append('temporal-aggregation', singleFrame);
+
     if (interval) {
         finalUrl.searchParams.append('interval', interval);
     }
@@ -66,7 +67,7 @@ const getFinalurl = (originalUrlString, { singleFrame, interval, proxy = true })
     }
     const filters = originalUrl.searchParams.get("filters")
     if (filters) {
-        finalUrl.searchParams.append('date-range', decodeURI(filters))
+        finalUrl.searchParams.append('filters', decodeURI(filters))
     }
 
     return decodeURI(finalUrl.toString());

--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -25,7 +25,10 @@ const getAggregationParams = params => {
         url.searchParams.get("quantizeOffset") || "0"
     );
     const singleFrame = url.searchParams.get("singleFrame") === "true";
+    // We want proxy active as default when api tiles auth is required
+    const proxy = url.searchParams.get("proxy") !== "false";
     const aggregationParams =  {
+        proxy,
         x, y, z,
         singleFrame,
         quantizeOffset,
@@ -47,23 +50,26 @@ const getAggregationParams = params => {
     return aggregationParams
 };
 
-const getFinalurl = (originalUrlString, { singleFrame, interval }) => {
+const getFinalurl = (originalUrlString, { singleFrame, interval, proxy = true }) => {
     const originalUrl = new URL(originalUrlString);
 
     const finalUrl = new URL(originalUrl.origin + originalUrl.pathname)
-
+    finalUrl.searchParams.append('proxy', proxy);
     finalUrl.searchParams.append('format', 'intArray');
-    if (originalUrl.searchParams.get("date-range")) {
-        finalUrl.searchParams.append('date-range', decodeURI(originalUrl.searchParams.get("date-range")))
-    }
     finalUrl.searchParams.append('temporal-aggregation', singleFrame);
     if (interval) {
         finalUrl.searchParams.append('interval', interval);
     }
+    const dateRange = originalUrl.searchParams.get("date-range")
+    if (dateRange) {
+        finalUrl.searchParams.append('date-range', decodeURI(dateRange))
+    }
+    const filters = originalUrl.searchParams.get("filters")
+    if (filters) {
+        finalUrl.searchParams.append('date-range', decodeURI(filters))
+    }
 
-    const finalUrlStr = `${finalUrl.toString()}&${originalUrl.searchParams.get("filters")}`
-
-    return decodeURI(finalUrlStr);
+    return decodeURI(finalUrl.toString());
 };
 
 const getVectorTileAggregated = (aggregatedGeoJSON, options) => {

--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -39,7 +39,10 @@ const getAggregationParams = params => {
         aggregationParams.interval = url.searchParams.get("interval")
     }
     if (url.searchParams.get("breaks")) {
-        aggregationParams.breaks = url.searchParams.get("breaks").split(",").map(v => parseFloat(v))
+        aggregationParams.breaks = JSON.parse(url.searchParams.get("breaks"))
+    }
+    if (url.searchParams.get("combinationMode")) {
+        aggregationParams.combinationMode = url.searchParams.get("combinationMode")
     }
     return aggregationParams
 };

--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -5,7 +5,7 @@ import GeoJSONWrapper from "./geojson_wrapper";
 import VectorTileWorkerSource from "./vector_tile_worker_source";
 import { getArrayBuffer } from "../util/ajax";
 import { extend } from "../util/util";
-import aggregateIntArray from "../util/aggregate";
+import aggregate from "../util/aggregate.mjs";
 import tilebelt from "@mapbox/tilebelt";
 
 
@@ -88,7 +88,7 @@ const encodeVectorTile = (data, aggregateParams) => {
     const int16ArrayBuffer = decodeProto(data);
     const {x, y, z} = aggregateParams;
     const tileBBox = tilebelt.tileToBBOX([x, y, z]);
-    const aggregated = aggregateIntArray(int16ArrayBuffer, { ...aggregateParams, tileBBox });
+    const aggregated = aggregate(int16ArrayBuffer, { ...aggregateParams, tileBBox });
     const aggregatedVectorTile = getVectorTileAggregated(aggregated, aggregateParams);
     return aggregatedVectorTile;
 };

--- a/src/util/aggregate.mjs
+++ b/src/util/aggregate.mjs
@@ -80,14 +80,7 @@ const aggregate = (intArray, options) => {
         breaks,
         x, y, z,
         numDatasets,
-        // TODO make me configurable
-        skipOddCells = false,
     } = options;
-    // TODO Here assuming that BLOB --> animation frame. Should it be configurable in another way?
-    //      Generator could set it by default to BLOB, but it could be overridden by layer params
-    // TODO Should be aggregation, not skipping
-    // const skipOddCells = geomType === GEOM_TYPES.BLOB;
-
     const features = [];
 
     let aggregating = Array(numDatasets).fill([]);
@@ -105,12 +98,6 @@ const aggregate = (intArray, options) => {
     let tail;
 
     const writeValueToFeature = quantizedTail => {
-        // TODO add skipOddCells check
-        // console.log(skipOddCells, currentFeatureCell)
-        if (skipOddCells === true && currentFeatureCell % 4 !== 0) {
-            return;
-        }
-
         // TODO - do we really need that?
         // TODO - will need to work with currentAggregatedValues array
         // if (currentAggregatedValue <= 0) {

--- a/src/util/aggregate.mjs
+++ b/src/util/aggregate.mjs
@@ -71,7 +71,6 @@ const getInitialFeature = () => ({
 });
 
 const aggregate = (intArray, options) => {
-    console.log(intArray, options)
     const {
         quantizeOffset = 0,
         tileBBox,
@@ -81,11 +80,13 @@ const aggregate = (intArray, options) => {
         breaks,
         x, y, z,
         numDatasets,
+        // TODO make me configurable
+        skipOddCells = false,
     } = options;
     // TODO Here assuming that BLOB --> animation frame. Should it be configurable in another way?
     //      Generator could set it by default to BLOB, but it could be overridden by layer params
     // TODO Should be aggregation, not skipping
-    const skipOddCells = geomType === GEOM_TYPES.BLOB;
+    // const skipOddCells = geomType === GEOM_TYPES.BLOB;
 
     const features = [];
 
@@ -159,7 +160,7 @@ const aggregate = (intArray, options) => {
     const numRows = intArray[0]
     const numCols = intArray[1]
 
-    const t = performance.now()
+    // const t = performance.now()
 
     // console.log(x, y, z, intArray)
 
@@ -275,6 +276,7 @@ const aggregate = (intArray, options) => {
             featureBufferPos++;
 
             // TODO take num datasets into account
+            console.log(featureBufferPos, currentFeatureTimestampDelta)
             const isEndOfFeature =
                 (featureBufferPos - BUFFER_HEADERS.length - 1) / numDatasets ===
                 currentFeatureTimestampDelta;
@@ -290,6 +292,8 @@ const aggregate = (intArray, options) => {
                 currentFeature.properties.id = currentFeatureCell
                 features.push(currentFeature);
                 currentFeature = getInitialFeature();
+
+                currentFeatureTimestampDelta = 0
                 featureBufferPos = 0;
                 featureBufferValuesPos = 0;
 
@@ -301,7 +305,7 @@ const aggregate = (intArray, options) => {
             }
         }
     }
-    console.log(performance.now()- t)
+    // console.log(performance.now()- t)
 
     const geoJSON = {
         type: "FeatureCollection",
@@ -310,13 +314,4 @@ const aggregate = (intArray, options) => {
     return geoJSON;
 };
 
-const aggregateIntArray = (intArray, options) => {
-    const aggregated = aggregate(intArray, {
-        ...options,
-        // TODO make me configurable
-        skipOddCells: false
-    });
-    return aggregated;
-};
-
-export default aggregateIntArray;
+export default aggregate;

--- a/src/util/aggregate.mjs
+++ b/src/util/aggregate.mjs
@@ -70,21 +70,18 @@ const getInitialFeature = () => ({
     geometry: {}
 });
 
-// Given breaks [[0, 10, 20, 30], [0, 10, 20, 30]]
-// If first dataset selected:
-// -0.1 -> 0
-// 0 -> undefined
-// 0.1 -> 1
-// 15 -> 2
-// 25 -> 3
-// 35 -> 4
-// If second dataset selected:
-// -0.1 -> 10
-// 0 -> undefined
-// 0.1 -> 11
-// 15 -> 12
-// 25 -> 13
-// 35 -> 14
+// Given breaks [[0, 10, 20, 30], [-15, -5, 0, 5, 15]]:
+//                                    |   |   |   |   |
+//                                    |   |   |   |   |
+//  if first dataset selected     [   0, 10, 20, 30  ] 
+//    index returned is:            0 | 1 | 2 | 3 | 4 | 
+//                                    |   |   |   |   |
+//  if 2nd dataset selected       [ -15, -5,  0,  5, 15] 
+//    index returned is:            0 | 1 | 2 | 3 | 4 | 5
+//                                    |   |   |   |   |
+// Note: 0 is a special value, feature is entirely omitted
+//                                            |
+//                                       undefined   
 
 const getBucketIndex = (breaks, value) => {
     let currentBucketIndex  

--- a/src/util/aggregate.mjs
+++ b/src/util/aggregate.mjs
@@ -71,7 +71,6 @@ const getInitialFeature = () => ({
 });
 
 const aggregate = (intArray, options) => {
-    console.log(intArray, options)
     const {
         quantizeOffset = 0,
         tileBBox,
@@ -81,11 +80,13 @@ const aggregate = (intArray, options) => {
         breaks,
         x, y, z,
         numDatasets,
+        // TODO make me configurable
+        skipOddCells = false,
     } = options;
     // TODO Here assuming that BLOB --> animation frame. Should it be configurable in another way?
     //      Generator could set it by default to BLOB, but it could be overridden by layer params
     // TODO Should be aggregation, not skipping
-    const skipOddCells = geomType === GEOM_TYPES.BLOB;
+    // const skipOddCells = geomType === GEOM_TYPES.BLOB;
 
     const features = [];
 
@@ -110,7 +111,8 @@ const aggregate = (intArray, options) => {
             return;
         }
 
-        // TODO
+        // TODO - do we really need that?
+        // TODO - will need to work with currentAggregatedValues array
         // if (currentAggregatedValue <= 0) {
         //     return
         // }
@@ -122,16 +124,19 @@ const aggregate = (intArray, options) => {
             return
         }
 
-        let bucketIndex = 0
-        breaks.every((stopValue, i) => {
-            bucketIndex = i
+        let currentBucketIndex
+        for (let bucketIndex = 0; bucketIndex < breaks.length; bucketIndex++) {
+            const stopValue = breaks[bucketIndex];
             if (realValue <= stopValue) {
-                return false
+                currentBucketIndex = bucketIndex
+                break
             }
-            return true
-        })
+        }
+        if (currentBucketIndex === undefined) {
+            currentBucketIndex = breaks.length
+        }
         
-        currentFeature.properties[quantizedTail.toString()] = bucketIndex;
+        currentFeature.properties[quantizedTail.toString()] = currentBucketIndex;
     };
 
     // write values after tail > minTimestamp
@@ -159,7 +164,7 @@ const aggregate = (intArray, options) => {
     const numRows = intArray[0]
     const numCols = intArray[1]
 
-    const t = performance.now()
+    // const t = performance.now()
 
     // console.log(x, y, z, intArray)
 
@@ -227,35 +232,25 @@ const aggregate = (intArray, options) => {
                     currentFeatureMaxTimestamp = value;
                     currentFeatureTimestampDelta =
                         currentFeatureMaxTimestamp - currentFeatureMinTimestamp;
-                    // if (currentFeatureIndex === 0) {
-                    //     console.log('delta:',currentFeatureTimestampDelta)
-                    // }
                     break;
                 // actual value
                 default:
                     // when we are looking at ts 0 and delta is 10, we are in fact looking at the aggregation of day -9
                     tail = head - delta + 1;
-
-                    // const featureBufferValuesPos = featureBufferPos - BUFFER_HEADERS.length - 1
                     
-                    // TODO get dataset index
+                    // gets index of dataset, knowing that after headers values go 
+                    // dataset1, dataset2, dataset1, dataset2, ...
                     const datasetIndex = featureBufferValuesPos % numDatasets
-                    // if (currentFeatureIndex === 0) {
-                    //     console.log(featureBufferValuesPos)
-                    //     console.log(datasetIndex)
-                    //     console.log(aggregating)
-                    // }
 
-                    // TODO push at correct dataset index
+                    // collect value for this dataset
                     aggregating[datasetIndex].push(value);
 
                     let tailValue = 0;
                     if (tail > currentFeatureMinTimestamp) {
-                        // TODO get aggregating at correct dataset index
                         tailValue = aggregating[datasetIndex].shift();
                     }
 
-                    // TODO currentAggregatedValue*S*
+                    // collect "working" value, ie value at head by substracting tail value
                     currentAggregatedValues[datasetIndex] =
                         currentAggregatedValues[datasetIndex] + value - tailValue;
 
@@ -265,7 +260,7 @@ const aggregate = (intArray, options) => {
                         writeValueToFeature(quantizedTail);
                     }
 
-                    // TODO *only if* last of datasets for frame
+                    // When all dataset values have been collected for this frame, we can move to next frame
                     if (datasetIndex === numDatasets - 1) {
                         head++;
                     }
@@ -274,9 +269,8 @@ const aggregate = (intArray, options) => {
             }
             featureBufferPos++;
 
-            // TODO take num datasets into account
             const isEndOfFeature =
-                (featureBufferPos - BUFFER_HEADERS.length - 1) / numDatasets ===
+                ((featureBufferPos - BUFFER_HEADERS.length) / numDatasets) - 1 ===
                 currentFeatureTimestampDelta;
 
             if (isEndOfFeature) {
@@ -290,6 +284,8 @@ const aggregate = (intArray, options) => {
                 currentFeature.properties.id = currentFeatureCell
                 features.push(currentFeature);
                 currentFeature = getInitialFeature();
+
+                currentFeatureTimestampDelta = 0
                 featureBufferPos = 0;
                 featureBufferValuesPos = 0;
 
@@ -301,7 +297,7 @@ const aggregate = (intArray, options) => {
             }
         }
     }
-    console.log(performance.now()- t)
+    // console.log(performance.now()- t)
 
     const geoJSON = {
         type: "FeatureCollection",
@@ -310,13 +306,4 @@ const aggregate = (intArray, options) => {
     return geoJSON;
 };
 
-const aggregateIntArray = (intArray, options) => {
-    const aggregated = aggregate(intArray, {
-        ...options,
-        // TODO make me configurable
-        skipOddCells: false
-    });
-    return aggregated;
-};
-
-export default aggregateIntArray;
+export default aggregate;

--- a/src/util/aggregate.test.mjs
+++ b/src/util/aggregate.test.mjs
@@ -1,0 +1,40 @@
+import aggregate from "./aggregate.mjs";
+import tap from 'tap'
+
+const BASE_CONFIG = {
+  breaks: [0, 1, 5, 10, 15, 30],
+  delta: 30,
+  geomType: "gridded",
+  interval: "day",
+  numDatasets: 1,
+  quantizeOffset: 15340,
+  singleFrame: false,
+  tileBBox: [-22.5, -21.943045533438177, 0, 0],
+  x: 7,
+  y: 8,
+  z: 4
+}
+
+const aggregateWith = (intArray, configOverrides) => aggregate(intArray, { ...BASE_CONFIG, ...configOverrides })
+const getAt = (intArray, configOverrides, featureIndex, timeIndex, expect) => {
+  const agg = aggregateWith(
+    intArray,
+    configOverrides
+  )
+  const at = agg.features[featureIndex].properties[timeIndex]
+  return at
+  tap.equal(
+    at, 
+    expect
+  )
+}
+
+tap.equal(getAt([1,1,0,15340,15340,42], {}, 0, 0), 1)
+tap.equal(getAt([1,1,0,15341,15341,42], {}, 0, 0), 1)
+tap.equal(getAt([1,1,0,15341,15341,142], {}, 0, 0), 2)
+tap.equal(getAt([1,1,0,15341,15341,999999], {}, 0, 0), 6)
+tap.equal(getAt([1,1,0,15341,15341,0], {}, 0, 0), 0)
+tap.equal(getAt([1,1,0,15341,15341,42], { breaks: undefined }, 0, 0), .42)
+
+tap.equal(getAt([1,1,0,15341,15341,42,456789], { numDatasets: 2, breaks: undefined }, 0, 0), .42)
+tap.equal(getAt([100,100,0,15341,15341,42,1234,1,15341,15341,43,456789], { numDatasets: 2, breaks: undefined }, 1, 0), .43)

--- a/src/util/aggregate.test.mjs
+++ b/src/util/aggregate.test.mjs
@@ -2,10 +2,11 @@ import aggregate from "./aggregate.mjs";
 import tap from 'tap'
 
 const BASE_CONFIG = {
-  breaks: [0, 1, 5, 10, 15, 30],
+  breaks: [[0, 1, 5, 10, 15, 30]],
   delta: 30,
-  geomType: "gridded",
-  interval: "day",
+  geomType: 'gridded',
+  interval: 'day',
+  combinationMode: 'add',
   numDatasets: 1,
   quantizeOffset: 15340,
   singleFrame: false,
@@ -23,18 +24,17 @@ const getAt = (intArray, configOverrides, featureIndex, timeIndex, expect) => {
   )
   const at = agg.features[featureIndex].properties[timeIndex]
   return at
-  tap.equal(
-    at, 
-    expect
-  )
 }
 
 tap.equal(getAt([1,1,0,15340,15340,42], {}, 0, 0), 1)
 tap.equal(getAt([1,1,0,15341,15341,42], {}, 0, 0), 1)
 tap.equal(getAt([1,1,0,15341,15341,142], {}, 0, 0), 2)
 tap.equal(getAt([1,1,0,15341,15341,999999], {}, 0, 0), 6)
-tap.equal(getAt([1,1,0,15341,15341,0], {}, 0, 0), 0)
+tap.equal(getAt([1,1,0,15341,15341,0], {}, 0, 0), undefined)
 tap.equal(getAt([1,1,0,15341,15341,42], { breaks: undefined }, 0, 0), .42)
 
-tap.equal(getAt([1,1,0,15341,15341,42,456789], { numDatasets: 2, breaks: undefined }, 0, 0), .42)
-tap.equal(getAt([100,100,0,15341,15341,42,1234,1,15341,15341,43,456789], { numDatasets: 2, breaks: undefined }, 1, 0), .43)
+tap.equal(getAt([1,1,0,15341,15341,42,43], { numDatasets: 2, breaks: undefined }, 0, 0), .85)
+tap.equal(getAt([100,100, 0,15341,15341,42,43, 1,15341,15341,52,53], { numDatasets: 2, breaks: undefined }, 1, 0), 1.05)
+tap.equal(getAt([100,100, 0,15341,15341,42,43], { numDatasets: 2, combinationMode: 'compare', breaks: undefined }, 0, 0), '1,0.43')
+tap.equal(getAt([100,100, 0,15341,15341,52,53], { numDatasets: 2, combinationMode: 'add' }, 0, 0), 2)
+tap.equal(getAt([100,100, 0,15341,15341,52,253], { numDatasets: 2, combinationMode: 'compare', breaks: [[0, 1, 5, 10, 15, 30], [0, 1, 2, 10, 15, 30]] }, 0, 0), 10 + 3)

--- a/src/util/aggregate.test.mjs
+++ b/src/util/aggregate.test.mjs
@@ -1,0 +1,43 @@
+import aggregate from "./aggregate.mjs";
+import tap from 'tap'
+
+const BASE_CONFIG = {
+  breaks: [0, 1, 5, 10, 15, 30],
+  delta: 30,
+  geomType: "gridded",
+  interval: "day",
+  numDatasets: 1,
+  quantizeOffset: 15340,
+  singleFrame: false,
+  tileBBox: [-22.5, -21.943045533438177, 0, 0],
+  x: 7,
+  y: 8,
+  z: 4
+}
+
+const aggregateWith = (intArray, configOverrides) => aggregate(intArray, { ...BASE_CONFIG, ...configOverrides })
+const getAt = (agg, featureIndex, timeIndex) => agg.features[featureIndex].properties[timeIndex]
+
+const test = (intArray, configOverrides, featureIndex, timeIndex, expect) => {
+  const agg = aggregateWith(
+    intArray,
+    configOverrides
+  )
+  console.log( agg.features)
+  const at = getAt(
+    agg,
+    featureIndex,
+    timeIndex
+  )
+  tap.equal(
+    at, 
+    expect
+  )
+}
+
+// test([1,1,0,15341,15341,42], {}, 0, 0, 1)
+// test([1,1,0,15341,15341,142], {}, 0, 0, 2)
+// test([1,1,0,15341,15341,42], { breaks: undefined }, 0, 0, .42)
+
+// test([1,1,0,15341,15341,42,456789], { numDatasets: 2, breaks: undefined }, 0, 0, .42)
+test([100,100,0,15341,15341,42,456789,1,15341,15341,43,456789], { numDatasets: 2, breaks: undefined }, 1, 0, .42)


### PR DESCRIPTION
Adds support for several datasets and combine modes (add and compare, bivariate in next PR)

Also adds a quick and dirty tests for aggregate than can be run using `test-aggregate` 