### PR TITLE
Only pass raw values in interactive source layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@globalfishingwatch/mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "1.12.0-gfw.9",
+  "version": "1.12.0-gfw.10",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@globalfishingwatch/mapbox-gl",
   "description": "A WebGL interactive maps library",
-  "version": "1.12.0-gfw.8",
+  "version": "1.12.0-gfw.9",
   "main": "dist/mapbox-gl.js",
   "style": "dist/mapbox-gl.css",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/source/temporalgrid_tile_worker_source.js
+++ b/src/source/temporalgrid_tile_worker_source.js
@@ -8,15 +8,6 @@ import { extend } from "../util/util";
 import aggregate from "../util/aggregate.mjs";
 import tilebelt from "@mapbox/tilebelt";
 
-
-const isoToDate = iso => {
-    return new Date(iso).getTime();
-};
-
-const isoToDay = iso => {
-    return isoToDate(iso) / 1000 / 60 / 60 / 24;
-};
-
 const getAggregationParams = params => {
     const url = new URL(params.request.url);
     const { x, y, z } = params.tileID.canonical;

--- a/src/util/aggregate.mjs
+++ b/src/util/aggregate.mjs
@@ -22,16 +22,21 @@ const getCellCoords = (tileBBox, cell, numCols) => {
     };
 };
 
-const getPointFeature = (tileBBox, cell, numCols, numRows) => {
+const getPointFeature = (tileBBox, cell, numCols, numRows, addMeta) => {
     const [minX, minY] = tileBBox;
     const { col, row, width, height } = getCellCoords(tileBBox, cell, numCols);
 
     const pointMinX = minX + (col / numCols) * width;
     let pointMinY = minY + (row / numRows) * height;
 
+    const properties = (addMeta) ? {
+        _col: col,
+        _row: row,
+    } : {}
+
     return {
         type: "Feature",
-        properties: {},
+        properties,
         geometry: {
             type: "Point",
             coordinates: [pointMinX, pointMinY]
@@ -39,7 +44,7 @@ const getPointFeature = (tileBBox, cell, numCols, numRows) => {
     }
 };
 
-const getRectangleFeature = (tileBBox, cell, numCols, numRows) => {
+const getRectangleFeature = (tileBBox, cell, numCols, numRows, addMeta) => {
     const [minX, minY] = tileBBox;
     const { col, row, width, height } = getCellCoords(tileBBox, cell, numCols);
 
@@ -47,9 +52,15 @@ const getRectangleFeature = (tileBBox, cell, numCols, numRows) => {
     const squareMinY = minY + (row / numRows) * height;
     const squareMaxX = minX + ((col + 1) / numCols) * width;
     const squareMaxY = minY + ((row + 1) / numRows) * height;
+
+    const properties = (addMeta) ? {
+        _col: col,
+        _row: row,
+    } : {}
+
     return {
         type: "Feature",
-        properties: {},
+        properties,
         geometry: {
             type: "Polygon",
             coordinates: [
@@ -65,10 +76,10 @@ const getRectangleFeature = (tileBBox, cell, numCols, numRows) => {
     };
 };
 
-const getFeature = ({ geomType, tileBBox, cell, numCols, numRows, id }) => {
+const getFeature = ({ geomType, tileBBox, cell, numCols, numRows, id, addMeta }) => {
     const feature = (geomType === 'point')
-        ? getPointFeature(tileBBox, cell, numCols, numRows)
-        : getRectangleFeature(tileBBox, cell, numCols, numRows)
+        ? getPointFeature(tileBBox, cell, numCols, numRows, addMeta)
+        : getRectangleFeature(tileBBox, cell, numCols, numRows, addMeta)
 
     feature.id = id
 
@@ -270,7 +281,7 @@ const aggregate = (intArray, options) => {
                     }
                     currentFeature = getFeature(featureParams)
                     if (interactive) {
-                        currentFeatureInteractive = getFeature(featureParams)
+                        currentFeatureInteractive = getFeature({ ...featureParams, addMeta: true })
                     }
                     break;
                 // minTs


### PR DESCRIPTION
Instead of storing aggregated values in interactive sourceLayer, just pass for a given cell, the slice of the intArray needed (so raw values without aggregation. 
- makes tile generation 20% faster
- non aggregated values can be used for the timebar graph
- aggregation is now done on a per-cell basis, when needed by the interaction hook